### PR TITLE
fix(campaign-details): comment out conditional rendering for pubOffer…

### DIFF
--- a/src/components/publisher/campaigns/campaign-details.tsx
+++ b/src/components/publisher/campaigns/campaign-details.tsx
@@ -485,7 +485,7 @@ export function CampaignDetails({ campaignId }: { campaignId: number }) {
                     </div>
                   )}
 
-                  {offer.pubOfferStatus === 1 && (
+                  {/* {offer.pubOfferStatus === 1 && (
                     <div className="mt-6">
                       <Separator className="mb-4" />
                       <h4 className="mb-2 text-xs font-medium text-gray-900">
@@ -497,7 +497,7 @@ export function CampaignDetails({ campaignId }: { campaignId: number }) {
                         className="text-xs"
                       />
                     </div>
-                  )}
+                  )} */}
 
                   {offer.pubOfferStatus === 2 && (
                     <div className="mt-6">


### PR DESCRIPTION
…Status

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - The "Tracking URL" section is no longer displayed in the campaign details view for offers with a specific status. No other visible changes to the interface or functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->