### PR TITLE
fix(offer-details): add Publishers Tab to offer detail page and updat…

### DIFF
--- a/src/app/(platform)/advertiser/campaigns/[campaignId]/offers/[offerId]/page.tsx
+++ b/src/app/(platform)/advertiser/campaigns/[campaignId]/offers/[offerId]/page.tsx
@@ -576,7 +576,8 @@ export default function OfferDetailPage({
               </CardContent>
             </Card>
           </TabsContent>
-
+          
+          {/* Publishers Tab */}
           <TabsContent value="publishers" className="space-y-6">
             <Card>
               <CardHeader>

--- a/src/components/ui/textarea/copy-to-clipboard-textarea.tsx
+++ b/src/components/ui/textarea/copy-to-clipboard-textarea.tsx
@@ -15,7 +15,7 @@ import {
 } from "@/components/ui/tooltip"
 
 interface CopyToClipboardTextareaProps {
-  value: string
+  value: any
   id?: string
   className?: string
   rows?: number
@@ -29,6 +29,14 @@ export function CopyToClipboardTextarea({
 }: CopyToClipboardTextareaProps) {
   const [copied, setCopied] = useState<boolean>(false)
   const textareaRef = useRef<HTMLTextAreaElement>(null)
+
+  const stringValue = typeof value === 'string' 
+    ? value 
+    : (value === null || value === undefined)
+      ? ''
+      : typeof value === 'object' 
+        ? JSON.stringify(value, null, 2)
+        : String(value)
 
   const handleCopy = () => {
     if (textareaRef.current) {
@@ -45,7 +53,7 @@ export function CopyToClipboardTextarea({
         id={id}
         className={cn("pr-10", className)}
         rows={rows}
-        value={value}
+        value={stringValue}
         readOnly
         style={{ resize: "none" }}
       />


### PR DESCRIPTION
…e CopyToClipboardTextarea to handle various value types

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- The copy-to-clipboard textarea now supports displaying and copying a wider range of value types, including objects and non-string values.
- **Documentation**
	- Added a visual comment and improved formatting to clearly separate the Publishers tab section in the campaign offer details page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->