### PR TITLE
refactor(campaign-status): standardize status property naming in upda…

### DIFF
--- a/src/components/admin/campaigns/data-table/index.tsx
+++ b/src/components/admin/campaigns/data-table/index.tsx
@@ -109,7 +109,7 @@ export default function CampaignDataTable() {
   const handleUpdateStatus = (campaign: ICampaign, status: string) => {
     updateStatus({
       id: campaign.id,
-      campaignStatus: status,
+      status,
     })
   }
 
@@ -118,7 +118,7 @@ export default function CampaignDataTable() {
 
     updateStatus({
       id: selectedCampaign.id,
-      campaignStatus: "Rejected",
+      status: "Rejected",
       rejectReason,
     })
 

--- a/src/components/admin/campaigns/detail/campaign-header.tsx
+++ b/src/components/admin/campaigns/detail/campaign-header.tsx
@@ -145,7 +145,7 @@ function CampaignVerificationUI({ campaign }: { campaign: Campaign }) {
     updateStatus(
       {
         id: campaign.id,
-        campaignStatus: status,
+        status,
         rejectReason: reason,
       },
       {

--- a/src/hooks/campaign/index.tsx
+++ b/src/hooks/campaign/index.tsx
@@ -298,18 +298,18 @@ export const useUpdateCampaignStatus = () => {
   return useMutation({
     mutationFn: async ({
       id,
-      campaignStatus,
+      status,
       rejectReason,
     }: {
       id: number
-      campaignStatus: string
+      status: string
       rejectReason?: string
     }) => {
       try {
         const { data } = await apiClient.patch(
           `/api/affiliate-network/campaigns/admin/${id}/status`,
           {
-            campaignStatus,
+            status,
             rejectReason,
           }
         )


### PR DESCRIPTION
…te functions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated the naming of campaign status fields in various areas of the application to use a consistent property name for improved clarity. No changes to application behavior or user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->